### PR TITLE
Handing multiple definitions of operator<< by inline-ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ First we need to define our objective function. This must be a class inheriting 
 
 using namespace optimize;
 
-class Rosenbrock : public Function
+class WODT : public Function
 {
 private:
   static constexpr Scalar b = 100;
@@ -106,12 +106,12 @@ public:
 
 ### Constrained Minimization
 
-With our objective function `Rosenbrock` defined above, we can now use this to setup our problem and perform the minimization. In the example below, given the constraints `l` and `u` the correct solution is `f(x) = 7.75` at `[0.5, 0.5, 0.35]`, not `[1, 1, 1]` as it is for the unconstrained Rosenbrock problem.
+With our objective function `WODT` defined above, we can now use this to setup our problem and perform the minimization. In the example below, given the constraints `l` and `u` the correct solution is `f(x) = 7.75` at `[0.5, 0.5, 0.35]`, not `[1, 1, 1]` as it is for the unconstrained WODT problem.
 
 ```cpp
 int main()
 {
-  Rosenbrock f;                   // Objective function we wish to minimize
+  WODT f;                   // Objective function we wish to minimize
   Vector x {{   0,    5,    5}};  // Initial guess
   Vector l {{-0.5,  0.5, 0.35}};  // Lower bounds on x
   Vector u {{ 0.5,   10,   10}};  // Upper bounds on x
@@ -197,7 +197,7 @@ L-BFGS-B is equally able to handle unconstrained minimization. We can modify the
 ```cpp
 int main()
 {
-  Rosenbrock f;           // Objective function we wish to minimize
+  WODT f;           // Objective function we wish to minimize
   Vector x {{0, 5, 5}};   // Initial guess
 
   // With C++17 or greater we can omit the "<>"
@@ -240,7 +240,7 @@ Now create the solver by passing your callback function to the constructor. Alte
 ```cpp
 int main()
 {
-  Rosenbrock f;                   // Objective function we wish to minimize
+  WODT f;                   // Objective function we wish to minimize
   Vector x {{   0,    5,    5}};  // Initial guess
   Vector l {{-0.5,  0.5, 0.35}};  // Lower bounds on x
   Vector u {{ 0.5,   10,   10}};  // Upper bounds on x

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ First we need to define our objective function. This must be a class inheriting 
 
 using namespace optimize;
 
-class WODT : public Function
+class Rosenbrock : public Function
 {
 private:
   static constexpr Scalar b = 100;
@@ -111,7 +111,7 @@ With our objective function `WODT` defined above, we can now use this to setup o
 ```cpp
 int main()
 {
-  WODT f;                   // Objective function we wish to minimize
+  Rosenbrock f;                   // Objective function we wish to minimize
   Vector x {{   0,    5,    5}};  // Initial guess
   Vector l {{-0.5,  0.5, 0.35}};  // Lower bounds on x
   Vector u {{ 0.5,   10,   10}};  // Upper bounds on x

--- a/include/lbfgsb.h
+++ b/include/lbfgsb.h
@@ -46,7 +46,7 @@ namespace optimize
     double t; // Breakpoint for the variable i in x
   };
 
-  std::ostream& operator<<(std::ostream& os, const std::vector<Breakpoint>& breakpoints)
+  inline std::ostream& operator<<(std::ostream& os, const std::vector<Breakpoint>& breakpoints)
   {
     os << "breakpoints = ";
     if (breakpoints.size() == 0) {

--- a/include/solver.h
+++ b/include/solver.h
@@ -293,7 +293,7 @@ namespace optimize
   };
 
   // Prints the solver state including termination messages, if any
-  std::ostream& operator<<(std::ostream& os, const Solver& solver)
+  inline std::ostream& operator<<(std::ostream& os, const Solver& solver)
   {
     const State& curr_state = solver.curr_state;
     const StopState& stop_state = solver.stop_state;


### PR DESCRIPTION
The definition of ```operator<<``` in the header files is required to be ```inline```d, as you might otherwise get multiple definitions of the same function across your final binary.